### PR TITLE
Fix missing LogicalMin/LogicalMax

### DIFF
--- a/hrdc/stream/optimizer/global_merge.py
+++ b/hrdc/stream/optimizer/global_merge.py
@@ -13,8 +13,8 @@ class GlobalMerge(Optimizer):
         self.globals = {
             GlobalItem.Unit: Unit(0),
             GlobalItem.UnitExponent: UnitExponent(0),
-            GlobalItem.LogicalMinimum: LogicalMinimum(0),
-            GlobalItem.LogicalMaximum: LogicalMaximum(0),
+            GlobalItem.LogicalMinimum: None,
+            GlobalItem.LogicalMaximum: None,
             GlobalItem.PhysicalMinimum: PhysicalMinimum(0),
             GlobalItem.PhysicalMaximum: PhysicalMaximum(0),
             }


### PR DESCRIPTION
The global merge optimization pass initialized LogicalMin/LogicaMax to
zero, and thus if the actual value was zero it would be
removed from the output hid descriptor. Here we instead initialize it to
None causing it to be emitted on first use and then no longer emitted.

This is in accordance with the HID specification that specifies that a
LogicalMin/LogicalMax value is mandatory in the descriptor.
